### PR TITLE
Add 07_terraform_env_customised_v1.x_updated

### DIFF
--- a/07_terraform_env_customised_v1.x_updated/.envrc
+++ b/07_terraform_env_customised_v1.x_updated/.envrc
@@ -1,0 +1,23 @@
+if [ ! -d ".venv" ]; then
+  echo "Installing virtualenv for $(python -V)"
+  python -m venv .venv
+  echo "Activating $(python -V) virtualenv"
+  source $PWD/.venv/bin/activate
+  test -f $PWD/requirements.txt && pip3 install -r $PWD/requirements.txt --upgrade
+fi
+
+source $PWD/.venv/bin/activate
+export PATH=$(git rev-parse --show-toplevel)/bin:$PATH:$PWD/.venv/bin
+
+export AWS_DEFAULT_PROFILE=default
+
+export AWS_DEFAULT_REGION="$(aws configure get ${AWS_DEFAULT_PROFILE}.region)"
+export AWS_ACCESS_KEY_ID="$(aws configure get ${AWS_DEFAULT_PROFILE}.aws_access_key_id)"
+export AWS_SECRET_ACCESS_KEY="$(aws configure get ${AWS_DEFAULT_PROFILE}.aws_secret_access_key)"
+
+# https://www.terraform.io/docs/backends/types/s3.html
+export STATE_BACKEND="myorg-terraform-state"
+
+# https://github.com/hashicorp/terraform/blob/master/CHANGELOG.md
+export TERRAFORM_VERSION="1.0.4"
+#export TF_LOG=TRACE

--- a/07_terraform_env_customised_v1.x_updated/.terraform.lock.hcl
+++ b/07_terraform_env_customised_v1.x_updated/.terraform.lock.hcl
@@ -1,0 +1,116 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.54.0"
+  constraints = ">= 3.15.0, >= 3.40.0, >= 3.43.0"
+  hashes = [
+    "h1:iyxZssXd79FWHVGsMd1MuTO63LUum6JuVE0eJBWTYEs=",
+    "zh:06c2dfbbf8ca2bea50444c26c5159763fe9cbe92553c13a208b4df1035368f35",
+    "zh:2ea54ab59a3a4cf455a1f1589778ca0721ed5d6ad681d64cfa7f2036dcc6df61",
+    "zh:30719cb435dac60fa69564e2ce221d589be3a974daed966f88fae88782db3a67",
+    "zh:8b13e240955bd9181dd5d0081bbc7c03200b4493e2e9f52a783c5e1582e16311",
+    "zh:99b344ab400300309e27dea4195671d1b021dee44758d0a97236f171b8395cbf",
+    "zh:bc0d72a343b161c3b47ce78760b9deae0d9339e279c3be35a2e9f148c09c4688",
+    "zh:d905eaa3c074131d8e7e5207a3c9ddab73c32a792dcd97a1c9d52a2a9753c1b7",
+    "zh:dddc2752b9d6846eaef3b2e2486f8789df91d16794e7aae03c9d5d6cb1bc10eb",
+    "zh:ed1bee76d38117594f336bd2656135c7f85b4a1af3ff65d2a3e59a8107b9219a",
+    "zh:f1f1a0bebd03e479b072dde9831f573070f6deada2972f5b966dd4858b99a8c2",
+    "zh:f91a6dfbc46d523d5f90ae84ac6ee6bf0aa2b1ced9a55f6142669849d3608998",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/cloudinit" {
+  version = "2.2.0"
+  hashes = [
+    "h1:tQLNREqesrdCQ/bIJnl0+yUK+XfdWzAG0wo4lp10LvM=",
+    "zh:76825122171f9ea2287fd27e23e80a7eb482f6491a4f41a096d77b666896ee96",
+    "zh:795a36dee548e30ca9c9d474af9ad6d29290e0a9816154ad38d55381cd0ab12d",
+    "zh:9200f02cb917fb99e44b40a68936fd60d338e4d30a718b7e2e48024a795a61b9",
+    "zh:a33cf255dc670c20678063aa84218e2c1b7a67d557f480d8ec0f68bc428ed472",
+    "zh:ba3c1b2cd0879286c1f531862c027ec04783ece81de67c9a3b97076f1ce7f58f",
+    "zh:bd575456394428a1a02191d2e46af0c00e41fd4f28cfe117d57b6aeb5154a0fb",
+    "zh:c68dd1db83d8437c36c92dc3fc11d71ced9def3483dd28c45f8640cfcd59de9a",
+    "zh:cbfe34a90852ed03cc074601527bb580a648127255c08589bc3ef4bf4f2e7e0c",
+    "zh:d6ffd7398c6d1f359b96f5b757e77b99b339fbb91df1b96ac974fe71bc87695c",
+    "zh:d9c15285f847d7a52df59e044184fb3ba1b7679fd0386291ed183782683d9517",
+    "zh:f7dd02f6d36844da23c9a27bb084503812c29c1aec4aba97237fec16860fdc8c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version = "2.2.0"
+  hashes = [
+    "h1:rxDS2QQuG/M9aRSKlvW2oHsp5eGAoB1J9KZthCOVbeQ=",
+    "zh:01341dd1e9cc7e7f6999e11e7473bcdca2dd72dd27f91beed1f4fb599a15dfba",
+    "zh:20e86c9eccd3a81ef5ac243af31b61fc4d2d679437384bd0870e92fa1b3ed6c9",
+    "zh:22a71127c5dbea4f62edb5bcf00b5c163de04aa19d45a7a1f621f973ffd09d20",
+    "zh:28ab7c84a5f8ed82fc520668db93d650571ddf59d98845cb18a1fa1a7888efc0",
+    "zh:3985a30929ad8fdc6b94f0e1cbd62a63db75ee961b8ba7db1cf4bfd29e8009ff",
+    "zh:477d92e26ba0c906087a5dd827ac3917dad7d5af770ee0ab4b08d0f273150586",
+    "zh:750928ec5ef54b2090bd6a6d8a19630a8712bbbccc0429251e88ccd361c1d3c0",
+    "zh:a615841fd90094bddc1269127e501fa60453c441b9548ff73752fe14efc38ed0",
+    "zh:e762aca7883374fa255efba50f5bdf791fece7d61e3920e593fb1a2cbb598981",
+    "zh:f76f372ead52948ca53610b371cb80c80ebcf058ef0a5c0ce9f0ce38dcc9a8eb",
+    "zh:fa36fe93ed977f4478cc6547ec3c45c28e56f10632e85446b0c3d71449f8c4bb",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.4.1"
+  constraints = ">= 1.11.1"
+  hashes = [
+    "h1:wU6cDBN6KPhjbBvPWXRgryN9amNlhL/n9l39cFm3X/U=",
+    "zh:10a368f3a3f26d821f02b55f0c42bdd4d2cd0dc5e2568c513bce39d92d25526f",
+    "zh:2183272a6d44f23d562d47ff4d6592685d8797838bdae69a50f92121743b020f",
+    "zh:24c492d61ce4dbcac4bb4410bd5e657ab28d19ab320d41104148ee626b44f5ed",
+    "zh:291380db0cd581d806158e5ddfd7133592055151109fcf0c923644cede5f30c7",
+    "zh:46933ddae44108d1a2956d917bafdb8879147b204b1bfac0c238773d2587e288",
+    "zh:5b96c1c330d709d87faa44f1cc9b1db87baeba5056638fe07c51a9b5a67f297e",
+    "zh:9fbb4ac6de96f68df324adbb77fd5eee6138f534f5393dc3bac18e615c75e0d0",
+    "zh:b8da6bbb97c20ec6e26c0160060c24d4e91b5057342b8b93a43f4019ab36e344",
+    "zh:c12390d668ef2f4c943c385de3befb54c0bfd0f9a3aa28b6aec55f7db4f4a518",
+    "zh:dee3d13f664037ada51e6f51c7e1c1361e643e1e61fbc9403b0f3985caa29c90",
+    "zh:ed10c04a636fa4a0f6e5e6068cb2f9a0f976b596cbabb9bd429631e3ba7fa35a",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version     = "2.1.0"
+  constraints = ">= 1.4.0"
+  hashes = [
+    "h1:EYZdckuGU3n6APs97nS2LxZm3dDtGqyM4qaIvsmac8o=",
+    "zh:0f1ec65101fa35050978d483d6e8916664b7556800348456ff3d09454ac1eae2",
+    "zh:36e42ac19f5d68467aacf07e6adcf83c7486f2e5b5f4339e9671f68525fc87ab",
+    "zh:6db9db2a1819e77b1642ec3b5e95042b202aee8151a0256d289f2e141bf3ceb3",
+    "zh:719dfd97bb9ddce99f7d741260b8ece2682b363735c764cac83303f02386075a",
+    "zh:7598bb86e0378fd97eaa04638c1a4c75f960f62f69d3662e6d80ffa5a89847fe",
+    "zh:ad0a188b52517fec9eca393f1e2c9daea362b33ae2eb38a857b6b09949a727c1",
+    "zh:c46846c8df66a13fee6eff7dc5d528a7f868ae0dcf92d79deaac73cc297ed20c",
+    "zh:dc1a20a2eec12095d04bf6da5321f535351a594a636912361db20eb2a707ccc4",
+    "zh:e57ab4771a9d999401f6badd8b018558357d3cbdf3d33cc0c4f83e818ca8e94b",
+    "zh:ebdcde208072b4b0f8d305ebf2bfdc62c926e0717599dcf8ec2fd8c5845031c3",
+    "zh:ef34c52b68933bedd0868a13ccfd59ff1c820f299760b3c02e008dc95e2ece91",
+  ]
+}
+
+provider "registry.terraform.io/terraform-aws-modules/http" {
+  version     = "2.4.1"
+  constraints = ">= 2.4.1"
+  hashes = [
+    "h1:ZnkXcawrIr611RvZpoDzbtPU7SVFyHym+7p1t+PQh20=",
+    "zh:0111f54de2a9815ded291f23136d41f3d2731c58ea663a2e8f0fef02d377d697",
+    "zh:0740152d76f0ccf54f4d0e8e0753739a5233b022acd60b5d2353d248c4c17204",
+    "zh:569518f46809ec9cdc082b4dfd4e828236eee2b50f87b301d624cfd83b8f5b0d",
+    "zh:7669f7691de91eec9f381e9a4be81aa4560f050348a86c6ea7804925752a01bb",
+    "zh:81cd53e796ec806aca2d8e92a2aed9135661e170eeff6cf0418e54f98816cd05",
+    "zh:82f01abd905090f978b169ac85d7a5952322a5f0f460269dd981b3596652d304",
+    "zh:9a235610066e0f7e567e69c23a53327271a6fc568b06bf152d8fe6594749ed2b",
+    "zh:aeabdd8e633d143feb67c52248c85358951321e35b43943aeab577c005abd30a",
+    "zh:c20d22dba5c79731918e7192bc3d0b364d47e98a74f47d287e6cc66236bc0ed0",
+    "zh:c4fea2cb18c31ed7723deec5ebaff85d6795bb6b6ed3b954794af064d17a7f9f",
+    "zh:e21e88b6e7e55b9f29b046730d9928c65a4f181fd5f60a42f1cd41b46a0a938d",
+    "zh:eddb888a74dea348a0acdfee13a08875bacddde384bd9c28342a534269665568",
+    "zh:f46d5f1403b8d8dfafab9bdd7129d3080bb62a91ea726f477fd43560887b8c4a",
+  ]
+}

--- a/07_terraform_env_customised_v1.x_updated/Makefile
+++ b/07_terraform_env_customised_v1.x_updated/Makefile
@@ -1,0 +1,27 @@
+MAKEFLAGS += --silent
+
+.DEFAULT_GOAL := validate
+
+terraform := $(shell command -v terraform 2> /dev/null)
+
+ifndef terraform
+    $(error "terraform is not available please install")
+endif
+
+## Initialize terraform remote state
+init: 
+	[ -d .terraform ] || ${terraform} $@
+
+## Pass arguments through to terraform which require remote state
+apply destroy graph plan output providers show validate: init
+	${terraform} $@
+
+## Pass arguments through to terraform which do not require remote state
+get fmt version console:
+	${terraform} $@
+
+.PHONY: test
+test:
+	[ -f ./test/test.sh ] && ./test/test.sh || true
+
+-include include.mk

--- a/07_terraform_env_customised_v1.x_updated/README.md
+++ b/07_terraform_env_customised_v1.x_updated/README.md
@@ -1,0 +1,18 @@
+# Parametrising clusters as Terraform modules terraform > v1.x.x
+
+You can provision multiple EKS clusters with:
+
+```bash
+make plan
+make apply
+```
+
+It might take a while for the cluster to be creates (up to 15-20 minutes).
+
+At the end you will have:
+
+1. A cluster for development.
+1. A cluster for staging.
+1. A cluster for production.
+
+In the same folder you will find a kubeconfig file for each cluster.

--- a/07_terraform_env_customised_v1.x_updated/cluster/iam-policy.json
+++ b/07_terraform_env_customised_v1.x_updated/cluster/iam-policy.json
@@ -1,0 +1,140 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "acm:DescribeCertificate",
+        "acm:ListCertificates",
+        "acm:GetCertificate"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:CreateSecurityGroup",
+        "ec2:CreateTags",
+        "ec2:DeleteTags",
+        "ec2:DeleteSecurityGroup",
+        "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAddresses",
+        "ec2:DescribeInstances",
+        "ec2:DescribeInstanceStatus",
+        "ec2:DescribeInternetGateways",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeTags",
+        "ec2:DescribeVpcs",
+        "ec2:ModifyInstanceAttribute",
+        "ec2:ModifyNetworkInterfaceAttribute",
+        "ec2:RevokeSecurityGroupIngress"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:AddListenerCertificates",
+        "elasticloadbalancing:AddTags",
+        "elasticloadbalancing:CreateListener",
+        "elasticloadbalancing:CreateLoadBalancer",
+        "elasticloadbalancing:CreateRule",
+        "elasticloadbalancing:CreateTargetGroup",
+        "elasticloadbalancing:DeleteListener",
+        "elasticloadbalancing:DeleteLoadBalancer",
+        "elasticloadbalancing:DeleteRule",
+        "elasticloadbalancing:DeleteTargetGroup",
+        "elasticloadbalancing:DeregisterTargets",
+        "elasticloadbalancing:DescribeListenerCertificates",
+        "elasticloadbalancing:DescribeListeners",
+        "elasticloadbalancing:DescribeLoadBalancers",
+        "elasticloadbalancing:DescribeLoadBalancerAttributes",
+        "elasticloadbalancing:DescribeRules",
+        "elasticloadbalancing:DescribeSSLPolicies",
+        "elasticloadbalancing:DescribeTags",
+        "elasticloadbalancing:DescribeTargetGroups",
+        "elasticloadbalancing:DescribeTargetGroupAttributes",
+        "elasticloadbalancing:DescribeTargetHealth",
+        "elasticloadbalancing:ModifyListener",
+        "elasticloadbalancing:ModifyLoadBalancerAttributes",
+        "elasticloadbalancing:ModifyRule",
+        "elasticloadbalancing:ModifyTargetGroup",
+        "elasticloadbalancing:ModifyTargetGroupAttributes",
+        "elasticloadbalancing:RegisterTargets",
+        "elasticloadbalancing:RemoveListenerCertificates",
+        "elasticloadbalancing:RemoveTags",
+        "elasticloadbalancing:SetIpAddressType",
+        "elasticloadbalancing:SetSecurityGroups",
+        "elasticloadbalancing:SetSubnets",
+        "elasticloadbalancing:SetWebAcl"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreateServiceLinkedRole",
+        "iam:GetServerCertificate",
+        "iam:ListServerCertificates"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "cognito-idp:DescribeUserPoolClient"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "waf-regional:GetWebACLForResource",
+        "waf-regional:GetWebACL",
+        "waf-regional:AssociateWebACL",
+        "waf-regional:DisassociateWebACL"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "tag:GetResources",
+        "tag:TagResources"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "waf:GetWebACL"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "wafv2:GetWebACL",
+        "wafv2:GetWebACLForResource",
+        "wafv2:AssociateWebACL",
+        "wafv2:DisassociateWebACL"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "shield:DescribeProtection",
+        "shield:GetSubscriptionState",
+        "shield:DeleteProtection",
+        "shield:CreateProtection",
+        "shield:DescribeSubscription",
+        "shield:ListProtections"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/07_terraform_env_customised_v1.x_updated/cluster/main.tf
+++ b/07_terraform_env_customised_v1.x_updated/cluster/main.tf
@@ -1,0 +1,113 @@
+provider "aws" {
+  region = var.region
+}
+
+data "aws_eks_cluster" "cluster" {
+  name = module.eks.cluster_id
+}
+
+data "aws_eks_cluster_auth" "cluster" {
+  name = module.eks.cluster_id
+}
+
+variable "cluster_name" {
+}
+
+variable "instance_type" {
+}
+
+variable "region" {
+  default = "eu-west-1"
+}
+
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+  token                  = data.aws_eks_cluster_auth.cluster.token
+}
+
+data "aws_availability_zones" "available" {
+}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 2.47"
+
+  name                 = "k8s-${var.cluster_name}-vpc"
+  cidr                 = "172.16.0.0/16"
+  azs                  = data.aws_availability_zones.available.names
+  private_subnets      = ["172.16.1.0/24", "172.16.2.0/24", "172.16.3.0/24"]
+  public_subnets       = ["172.16.4.0/24", "172.16.5.0/24", "172.16.6.0/24"]
+  enable_nat_gateway   = true
+  single_nat_gateway   = true
+  enable_dns_hostnames = true
+
+  public_subnet_tags = {
+    "kubernetes.io/cluster/${var.cluster_name}" = "shared"
+    "kubernetes.io/role/elb"                    = "1"
+  }
+
+  private_subnet_tags = {
+    "kubernetes.io/cluster/${var.cluster_name}" = "shared"
+    "kubernetes.io/role/internal-elb"           = "1"
+  }
+}
+
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "17.1.0"
+
+  cluster_name    = "eks-${var.cluster_name}"
+  cluster_version = "1.20"
+  subnets         = module.vpc.private_subnets
+
+  vpc_id = module.vpc.vpc_id
+
+  node_groups = {
+    first = {
+      desired_capacity = 1
+      max_capacity     = 10
+      min_capacity     = 1
+
+      instance_type = var.instance_type
+    }
+  }
+
+  write_kubeconfig            = true
+  workers_additional_policies = [aws_iam_policy.worker_policy.arn]
+}
+
+resource "aws_iam_policy" "worker_policy" {
+  name        = "worker-policy-${var.cluster_name}"
+  description = "Worker policy for the ALB Ingress"
+
+  policy = file("${path.module}/iam-policy.json")
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = data.aws_eks_cluster.cluster.endpoint
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+    token                  = data.aws_eks_cluster_auth.cluster.token
+  }
+}
+
+resource "helm_release" "ingress" {
+  name       = "ingress"
+  chart      = "aws-alb-ingress-controller"
+  repository = "http://storage.googleapis.com/kubernetes-charts-incubator"
+  #version    = "1.0.2"
+
+  set {
+    name  = "autoDiscoverAwsRegion"
+    value = "true"
+  }
+  set {
+    name  = "autoDiscoverAwsVpcID"
+    value = "true"
+  }
+  set {
+    name  = "clusterName"
+    value = var.cluster_name
+  }
+}

--- a/07_terraform_env_customised_v1.x_updated/main.tf
+++ b/07_terraform_env_customised_v1.x_updated/main.tf
@@ -1,0 +1,37 @@
+provider "aws" {
+  region = "eu-west-1"
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+module "dev_cluster" {
+  source        = "./cluster"
+  cluster_name  = "dev"
+  instance_type = "t2.micro"
+}
+
+module "staging_cluster" {
+  source        = "./cluster"
+  cluster_name  = "staging"
+  instance_type = "t2.micro"
+}
+
+module "production_cluster" {
+  source = "./cluster"
+  #region        = "eu-central-1"
+  cluster_name  = "production"
+  instance_type = "m5.large"
+}
+
+output "self" {
+  description = "Runtime environment"
+  value = {
+    workspace   = terraform.workspace
+    last_update = timestamp()
+    account_id  = data.aws_caller_identity.current.account_id
+    region      = data.aws_region.current.name
+    user_id     = substr(data.aws_caller_identity.current.user_id, 0, 21)
+    web_console = format("https://%s.signin.aws.amazon.com/console", data.aws_caller_identity.current.account_id)
+  }
+}

--- a/07_terraform_env_customised_v1.x_updated/requirements.txt
+++ b/07_terraform_env_customised_v1.x_updated/requirements.txt
@@ -1,0 +1,5 @@
+boto
+boto3
+botocore
+awscli
+kubernetes

--- a/07_terraform_env_customised_v1.x_updated/test/test.sh
+++ b/07_terraform_env_customised_v1.x_updated/test/test.sh
@@ -1,0 +1,1 @@
+aws eks list-clusters

--- a/07_terraform_env_customised_v1.x_updated/versions.tf
+++ b/07_terraform_env_customised_v1.x_updated/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = "~> 1.0.4"
+
+  required_providers {
+    aws   = ">= 3.40.0"
+    local = ">= 1.4"
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "2.4.1"
+    }
+  }
+
+  # {{ STATE_BACKEND }}
+}

--- a/README.md
+++ b/README.md
@@ -11,4 +11,5 @@ Code samples:
 1. [Integrating the Helm provider with Terraform and EKS](04_terraform_helm_provider/README.md)
 1. [Encapsulating clusters as Terraform modules](05_terraform_env_module/README.md)
 1. [Parametrising clusters as Terraform modules](06_terraform_envs_customised/README.md)
+1. [Parametrising clusters as Terraform modules (terraform v1.x)](/07_terraform_env_customised_v1.x_updated/README.md)
 1. [Kubernetes files to deploy an "Hello World" application](kubernetes/README.md)


### PR DESCRIPTION
Updated version from `06_terraform_envs_customised`:

- Terraform v1.0.4
on linux_amd64
+ provider registry.terraform.io/hashicorp/aws v3.54.0
+ provider registry.terraform.io/hashicorp/cloudinit v2.2.0
+ provider registry.terraform.io/hashicorp/helm v2.2.0
+ provider registry.terraform.io/hashicorp/kubernetes v2.4.1
+ provider registry.terraform.io/hashicorp/local v2.1.0
+ provider registry.terraform.io/terraform-aws-modules/http v2.4.1
